### PR TITLE
Fix: Clear image hover preview cache on dimension change in folder tab

### DIFF
--- a/ui/folder_tab.py
+++ b/ui/folder_tab.py
@@ -182,6 +182,10 @@ class UiFolderTabWidget(UiBatchCropWidget):
         self._hover_timer.stop()
         self.image_preview.hide_preview()
 
+    def _clear_hover_preview_cache(self):
+        """Clear the hover preview cache."""
+        self.image_preview.clear_cache()
+
     def _is_image_file(self, file_path: str) -> bool:
         """Check if a file is an image"""
         path = Path(file_path)
@@ -206,6 +210,10 @@ class UiFolderTabWidget(UiBatchCropWidget):
         """Connect widget signals to handlers"""
         # Button connections
         self.cropButton.clicked.connect(self.folder_process)
+
+        # Clear hover preview cache when width or height changes
+        self.controlWidget.widthLineEdit.textChanged.connect(self._clear_hover_preview_cache)
+        self.controlWidget.heightLineEdit.textChanged.connect(self._clear_hover_preview_cache)
 
         # Register button dependencies with the TabStateManager
         ut.register_button_dependencies(


### PR DESCRIPTION
The ImageHoverPreview cache in the folder tab was not being cleared when the target width or height dimensions were modified. This resulted in stale previews being shown.

This change connects the textChanged signals of the width and height input fields in the UiFolderTabWidget to a method that clears the ImageHoverPreview's cache, ensuring that previews are re-rendered with the correct dimensions.