### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@
    uv pip install maturin
    ```
 
-4. Build the Rust extension and install dependancies:
+4. Build the Rust extension and install dependencies:
 
    ```bash
    maturin develop


### PR DESCRIPTION
## Summary
- correct spelling in installation steps

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68408f794648832eb0b0b1a360aa04cb