### PR TITLE
Fix docstring for PathLineEdit method

### DIFF
--- a/line_edits/path_line_edit.py
+++ b/line_edits/path_line_edit.py
@@ -23,7 +23,7 @@ class PathLineEdit(CustomLineEdit):
         parent (Optional[QWidget]): The parent widget. Defaults to None.
 
     Methods:
-        insert_clipboard_path(self, text: str) -> None: Inserts the clipboard path into the text input.
+        insert_clipboard_path(self) -> None: Inserts the clipboard path into the text input.
         validate_path(self) -> None: Validates the path entered in the text input based on the selected path type.
         is_valid_image(path: Path) -> bool: Checks if the given path is a valid image file.
         is_valid_table(path: Path) -> bool: Checks if the given path is a valid table file.


### PR DESCRIPTION
## Summary
- correct signature for `insert_clipboard_path` in `path_line_edit.py`

## Testing
- `cargo test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68408fe3dac0832e9af32c198e8de913